### PR TITLE
feat: Refactor screen compatibility to <supports-screens>

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,22 +1,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <compatible-screens>
-        <screen android:screenSize="small" android:screenDensity="ldpi" />
-        <screen android:screenSize="small" android:screenDensity="mdpi" />
-        <screen android:screenSize="small" android:screenDensity="hdpi" />
-        <screen android:screenSize="small" android:screenDensity="xhdpi" />
-        <screen android:screenSize="small" android:screenDensity="xxhdpi" />
-        <screen android:screenSize="small" android:screenDensity="xxxhdpi" />
-        <screen android:screenSize="normal" android:screenDensity="ldpi" />
-        <screen android:screenSize="normal" android:screenDensity="mdpi" />
-        <screen android:screenSize="normal" android:screenDensity="hdpi" />
-        <screen android:screenSize="normal" android:screenDensity="xhdpi" />
-        <screen android:screenSize="normal" android:screenDensity="xxhdpi" />
-        <screen android:screenSize="normal" android:screenDensity="xxxhdpi" />
-    </compatible-screens>
     <application
         android:label="Invoice"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
+        <supports-screens
+            android:anyDensity="true"
+            android:largeScreens="false"
+            android:normalScreens="true"
+            android:resizeable="true"
+            android:smallScreens="true"
+            android:xlargeScreens="false" />
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
This commit refactors how our application declares its supported screen sizes within the Android Manifest. We are moving away from the less flexible and more error-prone <compatible-screens> tag to the recommended <supports-screens> element.

**Key changes:**
- Removed existing <compatible-screens> entries.
- Added a <supports-screens> tag within the <application> block.

**Configuration for Phone-Only Targeting:**
- `android:smallScreens="true"`: Enables support for small phone screens.
- `android:normalScreens="true"`: Enables support for typical smartphone screens.
- `android:largeScreens="false"`: Explicitly filters out 7-inch tablet-sized devices from Play Store distribution.
- `android:xlargeScreens="false"`: Explicitly filters out 10-inch+ tablet-sized devices from Play Store distribution.
- `android:anyDensity="true"` and `android:resizeable="true"` are maintained for broader density support and general responsiveness.

**Rationale:**
This change provides a clearer and more maintainable way to communicate our app's intended device compatibility to the Google Play Store. It simplifies future updates, as extending support to tablets will only require changing a few boolean flags rather than exhaustively listing screen configurations. This also aligns our project with current Android development best practices for screen management.