### PR TITLE
fix(android): Relocate <supports-screens> to manifest root

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,15 +1,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <supports-screens
+        android:anyDensity="true"
+        android:largeScreens="false"
+        android:normalScreens="true"
+        android:resizeable="true"
+        android:smallScreens="true"
+        android:xlargeScreens="false" />
     <application
         android:label="Invoice"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
-        <supports-screens
-            android:anyDensity="true"
-            android:largeScreens="false"
-            android:normalScreens="true"
-            android:resizeable="true"
-            android:smallScreens="true"
-            android:xlargeScreens="false" />
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
Corrected the placement of the <supports-screens> tag in AndroidManifest.xml.
It was incorrectly nested within the <application> tag, leading to a build error:
"error: unexpected element <supports-screens> found in <manifest><application>".

This commit moves the tag to be a direct child of the <manifest> element, as per Android documentation.
The configuration for phone-only screen targeting (small and normal screens supported, large and xlarge excluded)
remains the same.